### PR TITLE
13 add option to include a link in column header name

### DIFF
--- a/examples/src/components/examples/ExampleDynamicColumnTitle.vue
+++ b/examples/src/components/examples/ExampleDynamicColumnTitle.vue
@@ -3,10 +3,24 @@
     <InfineonDatatable
       :data="rows"
       :columns="columns"
-      :default-sort="{ key: 'name', type: 'D' }"
+      :default-sort="{ key: 'titleWithHref', type: 'D' }"
       :can-edit="true"
       @save-row="saveRow"
-    />
+    >
+      <!--Default column title slot-->
+      <!-- <template #col="{ title }">
+        {{ title }}
+      </template> -->
+
+      <!--Special column title slot-->
+      <!-- eslint-disable-next-line vue/valid-v-slot -->
+      <template #col.TitleWithHref="{ title, link }">
+        <a
+          :href="link"
+          target="_blank"
+        >{{ title }}</a>
+      </template>
+    </InfineonDatatable>
   </div>
 </template>
 
@@ -15,10 +29,10 @@ import { computed, ref } from 'vue';
 import { InfineonDatatable } from '../../../../lib';
 
 const rows = ref([
-  { id: 1, name: 'item1', type: 'A' },
-  { id: 2, name: 'item2' },
-  { id: 3, name: 'item3', type: 'C' },
-  { id: 4, name: 'item4', type: 'B' },
+  { id: 1, titleWithHref: 'item1', type: 'A' },
+  { id: 2, titleWithHref: 'item2' },
+  { id: 3, titleWithHref: 'item3', type: 'C' },
+  { id: 4, titleWithHref: 'item4', type: 'B' },
 ]);
 
 const dropdownOptions = computed(() => [
@@ -37,7 +51,7 @@ function getTypeForRow(row) {
 const saveRow = (changedRow) => {
   // update store here
   const originalRow = rows.value.find((r) => r.id === changedRow.id);
-  originalRow.name = changedRow.name;
+  originalRow.titleWithHref = changedRow.titleWithHref;
   originalRow.type = changedRow.type;
 };
 
@@ -49,8 +63,8 @@ const columns = [
     sortType: 'NUMBER',
   },
   {
-    key: 'name',
-    title: 'Name',
+    key: 'titleWithHref',
+    title: 'TitleWithHref',
     sortable: true,
     sortType: 'STRING',
     editable: true,

--- a/examples/src/components/examples/ExampleDynamicColumnTitle.vue
+++ b/examples/src/components/examples/ExampleDynamicColumnTitle.vue
@@ -8,15 +8,15 @@
       @save-row="saveRow"
     >
       <!--Default column title slot-->
-      <!-- <template #col="{ title }">
-        {{ title }}
-      </template> -->
+      <template #column="{ title }">
+        <span style="color:red">{{ title }}</span>
+      </template>
 
       <!--Special column title slot-->
       <!-- eslint-disable-next-line vue/valid-v-slot -->
-      <template #col.TitleWithHref="{ title, link }">
+      <template #column.TitleWithHref="{ title }">
         <a
-          :href="link"
+          href="https://www.example.com"
           target="_blank"
         >{{ title }}</a>
       </template>
@@ -68,7 +68,6 @@ const columns = [
     sortable: true,
     sortType: 'STRING',
     editable: true,
-    link: 'https://www.example.com',
   },
   {
     key: 'type',

--- a/examples/src/components/examples/ExampleEdit.vue
+++ b/examples/src/components/examples/ExampleEdit.vue
@@ -54,7 +54,6 @@ const columns = [
     sortable: true,
     sortType: 'STRING',
     editable: true,
-    link: 'https://www.example.com',
   },
   {
     key: 'type',

--- a/examples/src/components/examples/ExampleEdit.vue
+++ b/examples/src/components/examples/ExampleEdit.vue
@@ -2,8 +2,8 @@
   <div>
     <InfineonDatatable :data="rows" :columns="columns" :default-sort="{ key: 'name', type: 'D' }" :can-edit="true"
       @save-row="saveRow">
-      <template #columnTitle="{ title, link, includesLink }">
-        <a v-if="includesLink" style="padding-right:1em"><a :href="link" target="_blank">
+      <template #columnTitle="{ title, link }">
+        <a v-if="link!==null" style="padding-right:1em"><a :href="link" target="_blank">
             {{ title }}
           </a></a>
         <a v-else style="padding-right:1em">{{title}}</a>
@@ -57,7 +57,6 @@ const columns = [
     sortable: true,
     sortType: 'STRING',
     editable: true,
-    includesLink: true,
     link: 'https://www.example.com',
   },
   {

--- a/examples/src/components/examples/ExampleEdit.vue
+++ b/examples/src/components/examples/ExampleEdit.vue
@@ -1,12 +1,15 @@
 <template>
   <div>
-    <InfineonDatatable
-      :data="rows"
-      :columns="columns"
-      :default-sort="{ key: 'name', type: 'D' }"
-      :can-edit="true"
-      @save-row="saveRow"
-    />
+    <InfineonDatatable :data="rows" :columns="columns" :default-sort="{ key: 'name', type: 'D' }" :can-edit="true"
+      @save-row="saveRow">
+      <template #columnTitle="{ title, link, includesLink }">
+        <a v-if="includesLink" style="padding-right:1em"><a :href="link" target="_blank">
+            {{ title }}
+          </a></a>
+        <a v-else style="padding-right:1em">{{title}}</a>
+      </template>
+
+    </InfineonDatatable>/>
   </div>
 </template>
 

--- a/examples/src/components/examples/ExampleEdit.vue
+++ b/examples/src/components/examples/ExampleEdit.vue
@@ -54,6 +54,8 @@ const columns = [
     sortable: true,
     sortType: 'STRING',
     editable: true,
+    includesLink: true,
+    link: 'https://www.example.com',
   },
   {
     key: 'type',

--- a/examples/src/components/global/TheHeader.vue
+++ b/examples/src/components/global/TheHeader.vue
@@ -83,6 +83,10 @@ const links = ref([
         routeName: 'exampleEdit',
       },
       {
+        label: 'Dynamic Column Title',
+        routeName: 'exampleDynamicColumnTitle',
+      },
+      {
         label: 'Hideable Columns',
         routeName: 'exampleHideColumns',
       },

--- a/examples/src/router/router.js
+++ b/examples/src/router/router.js
@@ -3,6 +3,7 @@ import ExampleBasic from '../components/examples/ExampleBasic.vue';
 import ExampleEdit from '../components/examples/ExampleEdit.vue';
 import ExampleHideColumns from '../components/examples/ExampleHideColumns.vue';
 import ExampleAdditionalActions from '../components/examples/ExampleAdditionalActions.vue';
+import ExampleDynamicColumnTitle from '../components/examples/ExampleDynamicColumnTitle.vue';
 import IntroPage from '../components/IntroPage.vue';
 
 // this file initializes the vue router
@@ -25,6 +26,11 @@ const router = createRouter({
       path: '/example-edit',
       name: 'exampleEdit',
       component: ExampleEdit,
+    },
+    {
+      path: '/example-dynamic-column-title',
+      name: 'exampleDynamicColumnTitle',
+      component: ExampleDynamicColumnTitle,
     },
     {
       path: '/example-hide-columns',

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -9,14 +9,19 @@
               Actions
             </th>
 
-            <th v-for="(column, index) in shownColumns" :key="index" class="text-nowrap" scope="col">
-              <a v-if="column.includesLink"><a :href="column.link" target="_blank">
-                  {{ column.title }}
-                </a></a>
-              <a v-else>
-                {{ column.title }}
-                <DatatableSortIcon v-model:sort-column="sortColumn" :column="column" />
-              </a>
+            <th
+              v-for="(column, index) in shownColumns"
+              :key="index"
+              class="text-nowrap"
+              scope="col"
+            >
+            <slot name="columnTitle" v-bind="column"></slot>
+
+              <DatatableSortIcon
+                v-model:sort-column="sortColumn"
+                :column="column"
+              />
+
               <a v-if="column.hidable" style="cursor: pointer" @click="changeColumnVisibility(column.key)">
                 <font-awesome-icon class="fa-sm ms-2" :icon="['fas', 'times']" />
               </a>
@@ -71,6 +76,7 @@ const props = defineProps({
   defaultSort: { type: Object, default: () => { } }, // {key: '', type: 'A/D'}
   additionalActions: { type: Array, default: () => [] },
   // [ { label: '', action: (row) => {}, icon: ['fas', 'list-ol'] } ]
+  slotProps: { type: String, default: 'Default' }
 });
 const emit = defineEmits(['saveRow']);
 

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -1,109 +1,49 @@
 <template>
-  <div
-    class="d-flex flex-column justify-content-center flex-grow-1 pt-3"
-    style="overflow:auto"
-  >
-    <div
-      class="flex-grow-1"
-      style="overflow:auto"
-    >
-      <table
-        class="table table-sm table-hover w-100"
-        style="border-collapse: separate;border-spacing: 0;"
-      >
+  <div class="d-flex flex-column justify-content-center flex-grow-1 pt-3" style="overflow:auto">
+    <div class="flex-grow-1" style="overflow:auto">
+      <table class="table table-sm table-hover w-100" style="border-collapse: separate;border-spacing: 0;">
         <thead>
           <tr>
-            <th
-              v-if="hiddenColumnKeys.length > 0"
-              style="width:0em"
-              class="p-0"
-            />
-            <th
-              v-if="canEdit || additionalActions.length > 0"
-              style="width:0em"
-              class="ps-2 pe-1"
-            >
+            <th v-if="hiddenColumnKeys.length > 0" style="width:0em" class="p-0" />
+            <th v-if="canEdit || additionalActions.length > 0" style="width:0em" class="ps-2 pe-1">
               Actions
             </th>
 
-            <th
-              v-for="(column, index) in shownColumns"
-              :key="index"
-              class="text-nowrap"
-              scope="col"
-            >
-              {{ column.title }}
-              <DatatableSortIcon
-                v-model:sort-column="sortColumn"
-                :column="column"
-              />
-              <a
-                v-if="column.hidable"
-                style="cursor: pointer"
-                @click="changeColumnVisibility(column.key)"
-              >
-                <font-awesome-icon
-                  class="fa-sm ms-2"
-                  :icon="['fas', 'times']"
-                />
+            <th v-for="(column, index) in shownColumns" :key="index" class="text-nowrap" scope="col">
+              <a v-if="column.includesLink"><a :href="column.link" target="_blank">
+                  {{ column.title }}
+                </a></a>
+              <a v-else>
+                {{ column.title }}
+                <DatatableSortIcon v-model:sort-column="sortColumn" :column="column" />
+              </a>
+              <a v-if="column.hidable" style="cursor: pointer" @click="changeColumnVisibility(column.key)">
+                <font-awesome-icon class="fa-sm ms-2" :icon="['fas', 'times']" />
               </a>
             </th>
           </tr>
         </thead>
 
         <tbody>
-          <DatatableRow
-
-            v-for="(row,idx) in processedData"
-            :key="row.id"
-            :row-index="idx"
-
-            :row="row"
-            :columns="realColumns"
-            :hidden-column-keys="hiddenColumnKeys"
-            :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)"
-            :can-edit="canEdit"
-            :additional-actions="additionalActions"
-            @start-edit-row="startEditRow"
-            @save-row="saveRow"
-            @cancel-row="cancelRow"
-          >
-            <template
-              v-for="(_, name) in $slots"
-              #[name]="slotData"
-            >
-              <slot
-                :name="name"
-                v-bind="slotData || {}"
-              />
+          <DatatableRow v-for="(row,idx) in processedData" :key="row.id" :row-index="idx" :row="row"
+            :columns="realColumns" :hidden-column-keys="hiddenColumnKeys"
+            :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)" :can-edit="canEdit"
+            :additional-actions="additionalActions" @start-edit-row="startEditRow" @save-row="saveRow"
+            @cancel-row="cancelRow">
+            <template v-for="(_, name) in $slots" #[name]="slotData">
+              <slot :name="name" v-bind="slotData || {}" />
             </template>
           </DatatableRow>
         </tbody>
       </table>
     </div>
     <div class="mt-1 d-flex flex-row">
-      <DatatablePager
-        v-model:currentPage="currentPage"
-        class="flex-grow-1"
-        :page-size="pageSize"
-        :count="count"
-        @update-page-size="updatePageSize"
-      />
-      <DatatableShowColumnsPicker
-        style="max-width:15em"
-        :columns="realColumns"
-        :hidden-column-keys="hiddenColumnKeys"
-        @change-column-visibility="changeColumnVisibility"
-      />
-      <div
-        v-if="exportable"
-        class="mt-1 ms-1"
-      >
-        <button
-          class="btn btn-sm btn-primary"
-          title="Download CSV File"
-          @click="exportCSV"
-        >
+      <DatatablePager v-model:currentPage="currentPage" class="flex-grow-1" :page-size="pageSize" :count="count"
+        @update-page-size="updatePageSize" />
+      <DatatableShowColumnsPicker style="max-width:15em" :columns="realColumns" :hidden-column-keys="hiddenColumnKeys"
+        @change-column-visibility="changeColumnVisibility" />
+      <div v-if="exportable" class="mt-1 ms-1">
+        <button class="btn btn-sm btn-primary" title="Download CSV File" @click="exportCSV">
           <font-awesome-icon :icon="['fas', 'file-download']" />
           Download
         </button>
@@ -128,7 +68,7 @@ const props = defineProps({
   data: { type: Array, default: () => [] },
   columns: { type: Array, default: () => [] },
   exportable: Boolean,
-  defaultSort: { type: Object, default: () => {} }, // {key: '', type: 'A/D'}
+  defaultSort: { type: Object, default: () => { } }, // {key: '', type: 'A/D'}
   additionalActions: { type: Array, default: () => [] },
   // [ { label: '', action: (row) => {}, icon: ['fas', 'list-ol'] } ]
 });
@@ -235,7 +175,7 @@ function startEditRow(row) {
   rowInEditMode.value = row ? { ...row } : undefined;
 }
 async function saveRow(row) {
-  console.log("saving row", row)
+  console.log('saving row', row);
   emit('saveRow', row);
   rowInEditMode.value = undefined;
 }
@@ -274,8 +214,8 @@ async function exportCSV() {
 }
 
 .stickyHeader {
-  position:sticky;
-  top:0;
+  position: sticky;
+  top: 0;
   border-bottom: 2px solid black;
   background-color: white
 }

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -23,7 +23,17 @@
               style="width:0em"
               class="ps-2 pe-1"
             >
-              Actions
+              <slot
+                :name="`column.actions`"
+                v-bind="{title: 'Actions'}"
+              />
+              <slot
+                v-if="!$slots[`column.actions`]"
+                name="column"
+                v-bind="{title: 'Actions'}"
+              >
+                Actions
+              </slot>
             </th>
 
             <th
@@ -34,8 +44,8 @@
             >
               <!--default column title slot - hidden for slot with specified column title-->
               <slot
-                v-if="!$slots[`col.${column.title}`]"
-                name="col"
+                v-if="!$slots[`column.${column.title}`]"
+                name="column"
                 v-bind="column"
               >
                 {{ column.title }}
@@ -43,7 +53,7 @@
 
               <!--special column title slot-->
               <slot
-                :name="`col.${column.title}`"
+                :name="`column.${column.title}`"
                 v-bind="column"
               />
 
@@ -144,7 +154,6 @@ const props = defineProps({
   defaultSort: { type: Object, default: () => { } }, // {key: '', type: 'A/D'}
   additionalActions: { type: Array, default: () => [] },
   // [ { label: '', action: (row) => {}, icon: ['fas', 'list-ol'] } ]
-  slotProps: { type: String, default: 'Default' },
 });
 const emit = defineEmits(['saveRow']);
 

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -1,11 +1,28 @@
 <template>
-  <div class="d-flex flex-column justify-content-center flex-grow-1 pt-3" style="overflow:auto">
-    <div class="flex-grow-1" style="overflow:auto">
-      <table class="table table-sm table-hover w-100" style="border-collapse: separate;border-spacing: 0;">
+  <div
+    class="d-flex flex-column justify-content-center flex-grow-1 pt-3"
+    style="overflow:auto"
+  >
+    <div
+      class="flex-grow-1"
+      style="overflow:auto"
+    >
+      <table
+        class="table table-sm table-hover w-100"
+        style="border-collapse: separate;border-spacing: 0;"
+      >
         <thead>
           <tr>
-            <th v-if="hiddenColumnKeys.length > 0" style="width:0em" class="p-0" />
-            <th v-if="canEdit || additionalActions.length > 0" style="width:0em" class="ps-2 pe-1">
+            <th
+              v-if="hiddenColumnKeys.length > 0"
+              style="width:0em"
+              class="p-0"
+            />
+            <th
+              v-if="canEdit || additionalActions.length > 0"
+              style="width:0em"
+              class="ps-2 pe-1"
+            >
               Actions
             </th>
 
@@ -15,40 +32,91 @@
               class="text-nowrap"
               scope="col"
             >
-            <slot name="columnTitle" v-bind="column"></slot>
+              <!--default column title slot - hidden for slot with specified column title-->
+              <slot
+                v-if="!$slots[`col.${column.title}`]"
+                name="col"
+                v-bind="column"
+              >
+                {{ column.title }}
+              </slot>
+
+              <!--special column title slot-->
+              <slot
+                :name="`col.${column.title}`"
+                v-bind="column"
+              />
 
               <DatatableSortIcon
                 v-model:sort-column="sortColumn"
                 :column="column"
               />
 
-              <a v-if="column.hidable" style="cursor: pointer" @click="changeColumnVisibility(column.key)">
-                <font-awesome-icon class="fa-sm ms-2" :icon="['fas', 'times']" />
+              <a
+                v-if="column.hidable"
+                style="cursor: pointer"
+                @click="changeColumnVisibility(column.key)"
+              >
+                <font-awesome-icon
+                  class="fa-sm ms-2"
+                  :icon="['fas', 'times']"
+                />
               </a>
             </th>
           </tr>
         </thead>
 
         <tbody>
-          <DatatableRow v-for="(row,idx) in processedData" :key="row.id" :row-index="idx" :row="row"
-            :columns="realColumns" :hidden-column-keys="hiddenColumnKeys"
-            :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)" :can-edit="canEdit"
-            :additional-actions="additionalActions" @start-edit-row="startEditRow" @save-row="saveRow"
-            @cancel-row="cancelRow">
-            <template v-for="(_, name) in $slots" #[name]="slotData">
-              <slot :name="name" v-bind="slotData || {}" />
+          <DatatableRow
+            v-for="(row,idx) in processedData"
+            :key="row.id"
+            :row-index="idx"
+            :row="row"
+            :columns="realColumns"
+            :hidden-column-keys="hiddenColumnKeys"
+            :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)"
+            :can-edit="canEdit"
+            :additional-actions="additionalActions"
+            @start-edit-row="startEditRow"
+            @save-row="saveRow"
+            @cancel-row="cancelRow"
+          >
+            <template
+              v-for="(_, name) in $slots"
+              #[name]="slotData"
+            >
+              <slot
+                :name="name"
+                v-bind="slotData || {}"
+              />
             </template>
           </DatatableRow>
         </tbody>
       </table>
     </div>
     <div class="mt-1 d-flex flex-row">
-      <DatatablePager v-model:currentPage="currentPage" class="flex-grow-1" :page-size="pageSize" :count="count"
-        @update-page-size="updatePageSize" />
-      <DatatableShowColumnsPicker style="max-width:15em" :columns="realColumns" :hidden-column-keys="hiddenColumnKeys"
-        @change-column-visibility="changeColumnVisibility" />
-      <div v-if="exportable" class="mt-1 ms-1">
-        <button class="btn btn-sm btn-primary" title="Download CSV File" @click="exportCSV">
+      <DatatablePager
+        v-model:currentPage="currentPage"
+        class="flex-grow-1"
+        :page-size="pageSize"
+        :count="count"
+        @update-page-size="updatePageSize"
+      />
+      <DatatableShowColumnsPicker
+        style="max-width:15em"
+        :columns="realColumns"
+        :hidden-column-keys="hiddenColumnKeys"
+        @change-column-visibility="changeColumnVisibility"
+      />
+      <div
+        v-if="exportable"
+        class="mt-1 ms-1"
+      >
+        <button
+          class="btn btn-sm btn-primary"
+          title="Download CSV File"
+          @click="exportCSV"
+        >
           <font-awesome-icon :icon="['fas', 'file-download']" />
           Download
         </button>
@@ -76,7 +144,7 @@ const props = defineProps({
   defaultSort: { type: Object, default: () => { } }, // {key: '', type: 'A/D'}
   additionalActions: { type: Array, default: () => [] },
   // [ { label: '', action: (row) => {}, icon: ['fas', 'list-ol'] } ]
-  slotProps: { type: String, default: 'Default' }
+  slotProps: { type: String, default: 'Default' },
 });
 const emit = defineEmits(['saveRow']);
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Dynamic column title component added for showcasing the case described below:
Datatable was updated to have a default slot for the column title (displaying column title) and a special one (here: displaying title with link to example URL).
If the special slot contains content, the default slot will be hidden for this column. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.4--canary.14.aa97dc606882cb635fd804f525f5d2e92524770d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.2.4--canary.14.aa97dc606882cb635fd804f525f5d2e92524770d.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.2.4--canary.14.aa97dc606882cb635fd804f525f5d2e92524770d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
