### PR TITLE
Store hidden cols per view feature added to datatable, Example added …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#2c7f5b",
+    "activityBar.background": "#2c7f5b",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#552976",
+    "activityBarBadge.foreground": "#e7e7e7",
+    "commandCenter.border": "#e7e7e799",
+    "sash.hoverBorder": "#2c7f5b",
+    "statusBar.background": "#1f5940",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#2c7f5b",
+    "statusBarItem.remoteBackground": "#1f5940",
+    "statusBarItem.remoteForeground": "#e7e7e7",
+    "titleBar.activeBackground": "#1f5940",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#1f594099",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.remoteColor": "#1f5940"
+}

--- a/examples/src/components/examples/ExampleStoreHiddenColumnsPerView.vue
+++ b/examples/src/components/examples/ExampleStoreHiddenColumnsPerView.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    Select view
+    <TreeSelect
+      v-model="localStorageKey"
+      style="min-width:10em"
+      :options="viewOptions"
+      placeholder="Click here to select view"
+      :clearable="true"
+      label="label"
+      :calculate-position="withPopper"
+    />
+    {{ localStorageKey === null ? 'test' : localStorageKey }}
+
+    <InfineonDatatable
+      :data="rows"
+      :columns="columns"
+      :local-storage-key="localStorageKey !== null ? localStorageKey : null"
+      :default-sort="{ key: 'name', type: 'D' }"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { InfineonDatatable } from '../../../../lib';
+import { TreeSelect } from '../../../../lib/plugins/treeView';
+
+const localStorageKey = ref(null);
+const viewOptions = ref([{ id: 'view1', label: 'View 1' }, { id: 'view2', label: 'View 2' }, { id: 'view3', label: 'View 3' }]);
+
+const rows = ref([
+  {
+    id: 1,
+    name: 'item1',
+    type: { id: 11, label: 'Label A' },
+    longText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent laoreet ultrices gravida. Quisque condimentum pretium feugiat. Nam vel gravida ipsum. Fusce dapibus justo ut neque molestie, sed scelerisque leo aliquet. Curabitur convallis dictum maximus. Nullam a facilisis leo. Morbi dignissim facilisis nisi, quis hendrerit mi porta a. Sed id accumsan ipsum. Aenean rutrum iaculis feugiat. Proin feugiat enim sed tortor mollis, id elementum dolor pretium. Mauris condimentum arcu vitae tortor elementum tincidunt.',
+  },
+  {
+    id: 2,
+    name: 'item2',
+    longText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent laoreet ultrices gravida. Quisque condimentum pretium feugiat. Nam vel gravida ipsum. Fusce dapibus justo ut neque molestie, sed scelerisque leo aliquet. Curabitur convallis dictum maximus. Nullam a facilisis leo. Morbi dignissim facilisis nisi, quis hendrerit mi porta a. Sed id accumsan ipsum. Aenean rutrum iaculis feugiat. Proin feugiat enim sed tortor mollis, id elementum dolor pretium. Mauris condimentum arcu vitae tortor elementum tincidunt.',
+  },
+  {
+    id: 3,
+    name: 'item3',
+    type: { id: 12, label: 'Label B' },
+    longText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent laoreet ultrices gravida. Quisque condimentum pretium feugiat. Nam vel gravida ipsum. Fusce dapibus justo ut neque molestie, sed scelerisque leo aliquet. Curabitur convallis dictum maximus. Nullam a facilisis leo. Morbi dignissim facilisis nisi, quis hendrerit mi porta a. Sed id accumsan ipsum. Aenean rutrum iaculis feugiat. Proin feugiat enim sed tortor mollis, id elementum dolor pretium. Mauris condimentum arcu vitae tortor elementum tincidunt.',
+  },
+  {
+    id: 4,
+    name: 'item4',
+    type: { id: 11, label: 'Label A' },
+    longText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent laoreet ultrices gravida. Quisque condimentum pretium feugiat. Nam vel gravida ipsum. Fusce dapibus justo ut neque molestie, sed scelerisque leo aliquet. Curabitur convallis dictum maximus. Nullam a facilisis leo. Morbi dignissim facilisis nisi, quis hendrerit mi porta a. Sed id accumsan ipsum. Aenean rutrum iaculis feugiat. Proin feugiat enim sed tortor mollis, id elementum dolor pretium. Mauris condimentum arcu vitae tortor elementum tincidunt.',
+  },
+]);
+
+const columns = [
+  {
+    key: 'id',
+    title: 'ID',
+    sortable: true,
+    sortType: 'NUMBER',
+  },
+  {
+    key: 'name',
+    title: 'Name',
+    sortable: true,
+    sortType: 'STRING',
+    editable: true,
+    hidable: true,
+  },
+  {
+    key: 'type',
+    title: 'Type',
+    sortable: true,
+    sortType: 'STRING',
+    hidable: true,
+  },
+  {
+    key: 'longText',
+    title: 'Text',
+    sortable: false,
+    hidable: true,
+    defaultHidden: true,
+  },
+];
+</script>

--- a/examples/src/components/examples/ExampleStoreHiddenColumnsPerView.vue
+++ b/examples/src/components/examples/ExampleStoreHiddenColumnsPerView.vue
@@ -10,7 +10,6 @@
       label="label"
       :calculate-position="withPopper"
     />
-    {{ localStorageKey === null ? 'test' : localStorageKey }}
 
     <InfineonDatatable
       :data="rows"

--- a/examples/src/components/global/TheHeader.vue
+++ b/examples/src/components/global/TheHeader.vue
@@ -91,6 +91,10 @@ const links = ref([
         routeName: 'exampleHideColumns',
       },
       {
+        label: 'Hideable Columns per view',
+        routeName: 'exampleStoreHiddenColumnsPerView',
+      },
+      {
         label: 'Additional Actions',
         routeName: 'exampleAdditionalActions',
       },

--- a/examples/src/router/router.js
+++ b/examples/src/router/router.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHashHistory } from 'vue-router';
 import ExampleBasic from '../components/examples/ExampleBasic.vue';
 import ExampleEdit from '../components/examples/ExampleEdit.vue';
 import ExampleHideColumns from '../components/examples/ExampleHideColumns.vue';
+import ExampleStoreHiddenColumnsPerView from '../components/examples/ExampleStoreHiddenColumnsPerView.vue';
 import ExampleAdditionalActions from '../components/examples/ExampleAdditionalActions.vue';
 import ExampleDynamicColumnTitle from '../components/examples/ExampleDynamicColumnTitle.vue';
 import IntroPage from '../components/IntroPage.vue';
@@ -36,6 +37,11 @@ const router = createRouter({
       path: '/example-hide-columns',
       name: 'exampleHideColumns',
       component: ExampleHideColumns,
+    },
+    {
+      path: '/example-store-hidden-columns-per-view',
+      name: 'exampleStoreHiddenColumnsPerView',
+      component: ExampleStoreHiddenColumnsPerView,
     },
     {
       path: '/example-additional-Actions',


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Based on the selection of a view (View 1, View 2, etc., to be selected from a dropdown menu), it is possible to store the hidden columns per view. This is done using local storage.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.17.64ad5ed43230a302566d0e54976ed0377f500afc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.3.1--canary.17.64ad5ed43230a302566d0e54976ed0377f500afc.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.3.1--canary.17.64ad5ed43230a302566d0e54976ed0377f500afc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
