### PR TITLE
Example for CSV export added,

### DIFF
--- a/examples/src/components/examples/ExampleCsvExport.vue
+++ b/examples/src/components/examples/ExampleCsvExport.vue
@@ -1,0 +1,42 @@
+<template>
+  <div>
+    <InfineonDatatable
+      :data="rows"
+      :columns="columns"
+      :default-sort="{ key: 'name', type: 'D' }"
+      :exportable="true"
+    />
+  </div>
+</template>
+
+<script setup>
+import { InfineonDatatable } from '../../../../lib';
+
+const rows = [
+  { id: 1, name: 'item1', description: 'description item 1' },
+  { id: 2, name: 'item2,dealing,with,commas', description: 'description item 2' },
+  { id: 3, name: 'item3', description: 'description item 3' },
+  { id: 4, name: 'item4', description: 'description item 4' },
+];
+
+const columns = [
+  {
+    key: 'id',
+    title: 'ID column title',
+    sortable: true,
+    sortType: 'NUMBER',
+  },
+  {
+    key: 'name',
+    title: 'Column, with comma',
+    sortable: true,
+    sortType: 'STRING',
+  },
+  {
+    key: 'description',
+    title: 'Description',
+    sortable: true,
+    sortType: 'STRING',
+  },
+];
+</script>

--- a/examples/src/components/global/TheHeader.vue
+++ b/examples/src/components/global/TheHeader.vue
@@ -102,6 +102,10 @@ const links = ref([
         label: 'Additional Actions',
         routeName: 'exampleAdditionalActions',
       },
+      {
+        label: 'CSV Export',
+        routeName: 'exampleCsvExport',
+      },
     ],
   },
 ]);

--- a/examples/src/router/router.js
+++ b/examples/src/router/router.js
@@ -6,6 +6,7 @@ import ExampleStoreHiddenColumnsPerView from '../components/examples/ExampleStor
 import ExampleAdditionalActions from '../components/examples/ExampleAdditionalActions.vue';
 import ExampleDynamicColumnTitle from '../components/examples/ExampleDynamicColumnTitle.vue';
 import ExampleConditionallyHideColumns from '../components/examples/ExampleConditionallyHideColumns.vue';
+import ExampleCsvExport from '../components/examples/ExampleCsvExport.vue';
 import IntroPage from '../components/IntroPage.vue';
 
 // this file initializes the vue router
@@ -53,6 +54,11 @@ const router = createRouter({
       path: '/example-conditionally-hide-columns',
       name: 'exampleConditionallyHideColumns',
       component: ExampleConditionallyHideColumns,
+    },
+    {
+      path: '/example-csv-export',
+      name: 'exampleCsvExport',
+      component: ExampleCsvExport,
     },
   ],
 });

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -275,12 +275,12 @@ function updatePageSize(size) {
 }
 
 async function exportCSV() {
-  const titles = shownColumns.value.map((col) => col.title);
+  const titles = shownColumns.value.map((col) => `"${col.title}"`);
   let csv = titles.join(',');
   csv += '\n';
   data.value.forEach((row) => {
     const values = shownColumns.value
-      .map((col) => (col.valueResolver ? col.valueResolver(row) : row[col.key]));
+      .map((col) => (col.valueResolver ? `"${col.valueResolver(row)}"` : `"${row[col.key]}"`));
     csv += values.join(',');
     csv += '\n';
   });


### PR DESCRIPTION
column titles and field values are not enclosed by double quotes to handle commas
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.1--canary.20.d306045f916534ac46d4c9e8f33262c2bb79e909.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.4.1--canary.20.d306045f916534ac46d4c9e8f33262c2bb79e909.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.4.1--canary.20.d306045f916534ac46d4c9e8f33262c2bb79e909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
