### PR TITLE
24 get value of row while in edit mode via emit

### DIFF
--- a/examples/src/components/examples/ExampleEdit.vue
+++ b/examples/src/components/examples/ExampleEdit.vue
@@ -6,6 +6,7 @@
       :default-sort="{ key: 'name', type: 'D' }"
       :can-edit="true"
       @save-row="saveRow"
+      @edit-mode-value="editModeValue"
     />
   </div>
 </template>
@@ -33,6 +34,14 @@ const dropdownOptions = computed(() => [
 function getTypeForRow(row) {
   return dropdownOptions.value.find((r) => r.id === row.type)?.label;
 }
+
+const editModeValue = (changedRow) => {
+  // update store here
+  const originalRow = rows.value.find((r) => r.id === changedRow.id);
+  console.log('get current row vals while in editMode:', originalRow, changedRow);
+  originalRow.name = changedRow.name;
+  originalRow.type = changedRow.type;
+};
 
 const saveRow = (changedRow) => {
   // update store here

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -263,6 +263,7 @@ function changeColumnVisibility(columnKey) {
 
 function startEditRow(row) {
   rowInEditMode.value = row ? { ...row } : undefined;
+  emit('editModeValue', row);
 }
 async function saveRow(row) {
   emit('saveRow', row);
@@ -271,6 +272,7 @@ async function saveRow(row) {
 function editModeValue(row) {
   emit('editModeValue', row);
 }
+
 function cancelRow() {
   rowInEditMode.value = undefined;
 }

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -90,6 +90,7 @@
             @start-edit-row="startEditRow"
             @save-row="saveRow"
             @cancel-row="cancelRow"
+            @edit-mode-value="editModeValue"
           >
             <template
               v-for="(_, name) in $slots"
@@ -156,7 +157,7 @@ const props = defineProps({
   additionalActions: { type: Array, default: () => [] },
   // [ { label: '', action: (row) => {}, icon: ['fas', 'list-ol'] } ]
 });
-const emit = defineEmits(['saveRow']);
+const emit = defineEmits(['saveRow', 'editModeValue']);
 
 const { data, columns, localStorageKey } = toRefs(props);
 const sortColumn = ref(props.defaultSort);
@@ -266,6 +267,9 @@ function startEditRow(row) {
 async function saveRow(row) {
   emit('saveRow', row);
   rowInEditMode.value = undefined;
+}
+function editModeValue(row) {
+  emit('editModeValue', row);
 }
 function cancelRow() {
   rowInEditMode.value = undefined;

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -163,7 +163,7 @@ const props = defineProps({
 const {
   row, columns, rowIndex, hiddenColumnKeys, canEdit, additionalActions,
 } = toRefs(props);
-const emit = defineEmits(['startEditRow', 'saveRow', 'cancelRow', 'onRowButtonClick']);
+const emit = defineEmits(['startEditRow', 'saveRow', 'cancelRow', 'onRowButtonClick', 'editRow', 'editModeValue']);
 
 const shownColumns = computed(() => columns.value
   .filter((c) => !c.hidable || !hiddenColumnKeys.value.includes(c.key)));

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -80,6 +80,7 @@
       :row="row"
       :column="column"
       :row-is-in-edit-mode="rowIsInEditMode"
+      @input="editModeValue"
     >
       <template
         v-for="(_, name) in $slots"
@@ -123,6 +124,7 @@
               :row="row"
               :column="column"
               :row-is-in-edit-mode="rowIsInEditMode"
+              @input="editModeValue"
             >
               <template
                 v-for="(_, name) in $slots"
@@ -190,6 +192,10 @@ function startEditRow() {
 }
 function saveRow() {
   emit('saveRow', editRow.value);
+}
+function editModeValue() {
+  // console.log('get current row while in editMode', editRow.value);
+  emit('editModeValue', editRow.value);
 }
 function cancelRow() {
   emit('cancelRow');


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Emitting the row value, once the row is being edited and once the input changes, so it can be used - in this case - for having selects that are related to each other
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.2--canary.25.1ab9e110d45d4a25ccdfd7115701c759aa3904cf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.5.2--canary.25.1ab9e110d45d4a25ccdfd7115701c759aa3904cf.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.5.2--canary.25.1ab9e110d45d4a25ccdfd7115701c759aa3904cf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
