### PR TITLE
Enhancement: Option to display some actions in a popup menu instead of the actions column

### DIFF
--- a/examples/src/components/examples/ExamplePopupMenuActions.vue
+++ b/examples/src/components/examples/ExamplePopupMenuActions.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <InfineonDatatable
+      :data="rows"
+      :columns="columns"
+      :default-sort="{ key: 'name', type: 'D' }"
+      :can-edit="true"
+      :additional-actions="[ {
+                               title: 'Print to Console.log',
+                               label: 'Console.log',
+                               action: logToConsole,
+                               icon: ['fas', 'exclamation-triangle']},
+                              ]"
+      :popup-menu-actions="[ {
+                               title: 'Open an alert box',
+                               label: 'Alert',
+                               action: showAlert,
+                               icon: ['fas', 'terminal']
+                             },
+                             {
+                               title: 'Open an alert box',
+                               label: 'Alert',
+                               action: showAlert,
+                               icon: ['fas', 'terminal']
+                             } ]"
+    />
+    <!-- don't forget to load any fontawesome icons in /plugins/fontawesome.js!! -->
+  </div>
+</template>
+
+<script setup>
+import { InfineonDatatable } from '../../../../lib';
+
+const logToConsole = (row) => {
+  // eslint-disable-next-line no-console
+  console.log('we print to current row to console');
+  // eslint-disable-next-line no-console
+  console.log(row);
+};
+
+const showAlert = (row) => {
+  // eslint-disable-next-line no-alert
+  alert(JSON.stringify(row));
+};
+
+const rows = [
+  { id: 1, name: 'item1' },
+  { id: 2, name: 'item2' },
+  { id: 3, name: 'item3' },
+  { id: 4, name: 'item4' },
+];
+
+const columns = [
+  {
+    key: 'id',
+    title: 'ID column title',
+    sortable: true,
+    sortType: 'NUMBER',
+  },
+  {
+    key: 'name',
+    title: 'Name',
+    sortable: true,
+    sortType: 'STRING',
+  },
+];
+</script>

--- a/examples/src/components/examples/ExamplePopupMenuActions.vue
+++ b/examples/src/components/examples/ExamplePopupMenuActions.vue
@@ -21,7 +21,8 @@
                                title: 'Open an alert box',
                                label: 'Alert',
                                action: showAlert,
-                               icon: ['fas', 'terminal']
+                               icon: ['fas', 'terminal'],
+                               canCloseMenu: true
                              } ]"
     />
     <!-- don't forget to load any fontawesome icons in /plugins/fontawesome.js!! -->

--- a/examples/src/components/examples/ExamplePopupMenuActions.vue
+++ b/examples/src/components/examples/ExamplePopupMenuActions.vue
@@ -24,6 +24,7 @@
                                icon: ['fas', 'terminal'],
                                canCloseMenu: true
                              } ]"
+      @on-menu-button-click="onMenuOpened"
     />
     <!-- don't forget to load any fontawesome icons in /plugins/fontawesome.js!! -->
   </div>
@@ -43,6 +44,10 @@ const showAlert = (row) => {
   // eslint-disable-next-line no-alert
   alert(JSON.stringify(row));
 };
+
+const onMenuOpened = (row) => {
+  console.log(`Menu triggered for row  ${row.id}`)
+}
 
 const rows = [
   { id: 1, name: 'item1' },

--- a/examples/src/components/global/TheHeader.vue
+++ b/examples/src/components/global/TheHeader.vue
@@ -107,6 +107,10 @@ const links = ref([
         routeName: 'exampleAdditionalActions',
       },
       {
+        label: 'Popup Menu Actions',
+        routeName: 'examplePopupMenuActions',
+      },
+      {
         label: 'CSV Export',
         routeName: 'exampleCsvExport',
       },

--- a/examples/src/router/router.js
+++ b/examples/src/router/router.js
@@ -4,6 +4,7 @@ import ExampleEdit from '../components/examples/ExampleEdit.vue';
 import ExampleHideColumns from '../components/examples/ExampleHideColumns.vue';
 import ExampleStoreHiddenColumnsPerView from '../components/examples/ExampleStoreHiddenColumnsPerView.vue';
 import ExampleAdditionalActions from '../components/examples/ExampleAdditionalActions.vue';
+import ExamplePopupMenuActions from '../components/examples/ExamplePopupMenuActions.vue';
 import ExampleDynamicColumnTitle from '../components/examples/ExampleDynamicColumnTitle.vue';
 import ExampleConditionallyHideColumns from '../components/examples/ExampleConditionallyHideColumns.vue';
 import ExampleCsvExport from '../components/examples/ExampleCsvExport.vue';
@@ -56,6 +57,11 @@ const router = createRouter({
       path: '/example-conditionally-hide-additional-actions',
       name: 'exampleConditionallyHideAdditionalActions',
       component: ExampleConditionallyHideAdditionalActions,
+    },
+    {
+      path: '/example-popup-menu-actions',
+      name: 'examplePopupMenuActions',
+      component: ExamplePopupMenuActions,
     },
     {
       path: '/example-conditionally-hide-columns',

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -93,7 +93,7 @@
             @save-row="saveRow"
             @cancel-row="cancelRow"
             @edit-mode-value="editModeValue"
-            @open-actions-popup-menu="closeOtherActionsPopupMenus"
+            @on-menu-button-click="closeOtherActionsPopupMenus"
           >
             <template
               v-for="(_, name) in $slots"
@@ -163,7 +163,7 @@ const props = defineProps({
   // customColHidden: { type: String, default: 'Custom column' },
   popupMenuActions: { type: Array, default: () => [] },
 });
-const emit = defineEmits(['saveRow', 'editModeValue', 'cancelRow']);
+const emit = defineEmits(['saveRow', 'editModeValue', 'cancelRow', 'onMenuButtonClick']);
 
 const {
   data, columns, localStorageKey,
@@ -287,6 +287,7 @@ function editModeValue(row) {
 
 function closeOtherActionsPopupMenus(row) {
   rowMenuIsOpen.value = row ? row : undefined;
+  emit('onMenuButtonClick', row);
 }
 
 function cancelRow(row) {

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -88,10 +88,12 @@
             :can-edit="canEdit"
             :additional-actions="additionalActions"
             :popup-menu-actions="popupMenuActions"
+            :is-menu-open="(row.id) === (rowMenuIsOpen?.id)"
             @start-edit-row="startEditRow"
             @save-row="saveRow"
             @cancel-row="cancelRow"
             @edit-mode-value="editModeValue"
+            @open-actions-popup-menu="closeOtherActionsPopupMenus"
           >
             <template
               v-for="(_, name) in $slots"
@@ -170,6 +172,7 @@ const sortColumn = ref(props.defaultSort);
 const currentPage = ref(0);
 const pageSize = ref(10);
 const rowInEditMode = ref(undefined);
+const rowMenuIsOpen = ref(undefined);
 const count = ref(0);
 
 const hiddenColumnKeys = ref([]);
@@ -241,6 +244,8 @@ const processedData = computed(() => {
   return sliced;
 });
 
+const closeRowMenusMap = ref(new Map(processedData.value.map((_, index) => [index, false])));
+
 // store hidden columns for a predefined property localStorageKey - if not defined, use default
 const hiddenColumnsLocalStorageKey = computed(() => localStorageKey.value || realColumns
   .value.map((c) => c.key).sort().join());
@@ -278,6 +283,10 @@ async function saveRow(row) {
 function editModeValue(row) {
   // console.log('edit mode val', row);
   emit('editModeValue', row);
+}
+
+function closeOtherActionsPopupMenus(row) {
+  rowMenuIsOpen.value = row ? row : undefined;
 }
 
 function cancelRow(row) {

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -87,6 +87,7 @@
             :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)"
             :can-edit="canEdit"
             :additional-actions="additionalActions"
+            :popup-menu-actions="popupMenuActions"
             @start-edit-row="startEditRow"
             @save-row="saveRow"
             @cancel-row="cancelRow"
@@ -158,7 +159,7 @@ const props = defineProps({
   // [ { label: '', action: (row) => {}, icon: ['fas', 'list-ol'] } ]
   additionalExportColumns: { type: Array, default: () => [] },
   // customColHidden: { type: String, default: 'Custom column' },
-
+  popupMenuActions: { type: Array, default: () => [] },
 });
 const emit = defineEmits(['saveRow', 'editModeValue', 'cancelRow']);
 

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -99,10 +99,10 @@
         >
           <template
             v-for="(popupMenuAction, idx) in popupMenuActions"
+            :key="idx"
           >
             <button
-              v-if="!popupMenuAction.visible || popupMenuAction.visible(row)"
-              :key="idx"
+              v-show="!popupMenuAction.visible || popupMenuAction.visible(row)"
               class="btn btn-outline-primary btn-sm"
               :class="{'ms-1': idx > 0}"
               :title="popupMenuAction.title"
@@ -262,6 +262,8 @@ function popupMenuActionOnClick(row, action, canCloseMenu) {
 }
 
 function closeMenuOnClickOutside(event) {
+  console.log(`click, on menu: ${menuRef.value.contains(event.target)}`);
+  console.log(event.target);
   if (menuRef.value.contains(event.target)) {
     showMenu.value = !forcedMenuClose.value;
     forcedMenuClose.value = false;

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -262,8 +262,6 @@ function popupMenuActionOnClick(row, action, canCloseMenu) {
 }
 
 function closeMenuOnClickOutside(event) {
-  console.log(`click, on menu: ${menuRef.value.contains(event.target)}`);
-  console.log(event.target);
   if (menuRef.value.contains(event.target)) {
     showMenu.value = !forcedMenuClose.value;
     forcedMenuClose.value = false;

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -81,6 +81,7 @@
         ref="menuButtonRef"
         class="btn btn-outline-primary btn-sm me-1"
         :style="additionalActions.length > 0 ? 'margin-left: 4px;' : ''"
+        style="position: relative"
         @click="openPopupMenu"
       >
         <font-awesome-icon :icon="['fas', 'ellipsis-h']" />
@@ -275,7 +276,7 @@ function cancelRow() {
   padding: 8px;
   margin-left: -3px;
   margin-top: -2px;
-  z-index: 256443;
+  z-index: 4656546797;
 }
 .row-odd {
     --bs-table-accent-bg: var(--bs-table-striped-bg);

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -107,7 +107,7 @@
               :class="{'ms-1': idx > 0}"
               :title="popupMenuAction.title"
               :style="popupMenuAction.style ? popupMenuAction.style : ''"
-              @click="(row) => popupMenuActionOnClick(row, popupMenuAction.action, popupMenuAction.canCloseMenu)"
+              @click="(event) => popupMenuActionOnClick(event, popupMenuAction.action, popupMenuAction.canCloseMenu)"
             >
               <div style="display: flex;">
                 <div 
@@ -254,11 +254,11 @@ function openPopupMenu(event) {
   showMenu.value =!showMenu.value || !menuButtonRef.value.contains(event.target);
 }
 
-function popupMenuActionOnClick(row, action, canCloseMenu) {
+function popupMenuActionOnClick(_, action, canCloseMenu) {
   if (canCloseMenu) {
     forcedMenuClose.value = true;
   }
-  action(row)
+  action(row.value)
 }
 
 function closeMenuOnClickOutside(event) {

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -89,7 +89,7 @@
         class="btn btn-outline-primary btn-sm me-1"
         :style="additionalActions.length > 0 ? 'margin-left: 4px;' : ''"
         style="position: relative"
-        @click="openPopupMenu"
+        @click="showPopupMenu"
       >
         <font-awesome-icon :icon="['fas', 'ellipsis-h']" />
         <div 
@@ -221,7 +221,7 @@ const props = defineProps({
 const {
   row, columns, rowIndex, hiddenColumnKeys, canEdit, additionalActions, popupMenuActions, popupMenuOpen, isMenuOpen
 } = toRefs(props);
-const emit = defineEmits(['startEditRow', 'saveRow', 'cancelRow', 'onRowButtonClick', 'editRow', 'editModeValue', 'openActionsPopupMenu']);
+const emit = defineEmits(['startEditRow', 'saveRow', 'cancelRow', 'onRowButtonClick', 'editRow', 'editModeValue', 'onMenuButtonClick']);
 
 const shownColumns = computed(() => columns.value
 .filter((c) => !c.hidable || !hiddenColumnKeys.value.includes(c.key)));
@@ -249,8 +249,8 @@ const menuActionButtonRefs = ref([]);
 const forcedMenuClose = ref(false);
 const showMenu = ref(false);
 
-function openPopupMenu(event) {
-  emit('openActionsPopupMenu', row.value);
+function showPopupMenu(event) {
+  emit('onMenuButtonClick', row.value);
   showMenu.value =!showMenu.value || !menuButtonRef.value.contains(event.target);
 }
 

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -80,7 +80,7 @@
         v-if="canEdit && (popupMenuActions.length > 0)"
         ref="menuButtonRef"
         class="btn btn-outline-primary btn-sm me-1"
-        style="margin-left: 4px;"
+        :style="additionalActions.length > 0 ? 'margin-left: 4px;' : ''"
         @click="openPopupMenu"
       >
         <font-awesome-icon :icon="['fas', 'ellipsis-h']" />

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -262,7 +262,7 @@ function popupMenuActionOnClick(_, action, canCloseMenu) {
 }
 
 function closeMenuOnClickOutside(event) {
-  if (menuRef.value.contains(event.target)) {
+  if (menuRef.value?.contains(event.target)) {
     showMenu.value = !forcedMenuClose.value;
     forcedMenuClose.value = false;
   }

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -65,15 +65,22 @@
           class="btn btn-outline-primary btn-sm"
           :class="{'ms-1': idx > 0}"
           :title="additionalAction.title"
+          :style="additionalAction.style ? additionalAction.style : ''"
           @click="additionalAction.action(row)"
         >
-          <font-awesome-icon
-            v-if="additionalAction.icon"
-            :icon="additionalAction.icon"
-          />
-          <span v-if="additionalAction.label">
-            {{ additionalAction.label }}
-          </span>
+          <div style="display: flex;">
+            <div 
+              :style="additionalAction.label ? 'margin-right: 4px;' : ''"
+            >
+              <font-awesome-icon
+                v-if="additionalAction.icon"
+                :icon="additionalAction.icon"
+              />
+            </div>  
+            <span v-if="additionalAction.label">
+              {{ additionalAction.label }}
+            </span>
+          </div>
         </button>
       </template>
       <button 
@@ -99,15 +106,22 @@
               class="btn btn-outline-primary btn-sm"
               :class="{'ms-1': idx > 0}"
               :title="popupMenuAction.title"
+              :style="popupMenuAction.style ? popupMenuAction.style : ''"
               @click="popupMenuAction.action(row)"
             >
-              <font-awesome-icon
-                v-if="popupMenuAction.icon"
-                :icon="popupMenuAction.icon"
-              />
-              <span v-if="popupMenuAction.label">
-                {{ popupMenuAction.label }}
-              </span>
+              <div style="display: flex;">
+                <div 
+                  :style="popupMenuAction.label ? 'margin-right: 4px;' : ''"
+                >
+                  <font-awesome-icon
+                    v-if="popupMenuAction.icon"
+                    :icon="popupMenuAction.icon"
+                  />
+                </div>  
+                <span v-if="popupMenuAction.label">
+                  {{ popupMenuAction.label }}
+                </span>
+              </div>
             </button>
           </template>
         </div>
@@ -237,11 +251,8 @@ function openPopupMenu() {
 }
 
 function closeMenuOnClickOutside(event) {
-  if (isMenuOpen.value 
-    && !menuRef.value.contains(event.target) 
-    && !menuButtonRef.value.contains(event.target)
-  ) {
-    isMenuOpen.value = false;
+  if (menuRef.value.contains(event.target)) {
+    isMenuOpen.value = true;
   }
 }
 

--- a/lib/datatable/InfineonDatatableRow.vue
+++ b/lib/datatable/InfineonDatatableRow.vue
@@ -223,10 +223,10 @@ const {
 const emit = defineEmits(['startEditRow', 'saveRow', 'cancelRow', 'onRowButtonClick', 'editRow', 'editModeValue']);
 
 const shownColumns = computed(() => columns.value
-  .filter((c) => !c.hidable || !hiddenColumnKeys.value.includes(c.key)));
+.filter((c) => !c.hidable || !hiddenColumnKeys.value.includes(c.key)));
 
 const hiddenColumns = computed(() => columns.value
-  .filter((c) => c.hidable && hiddenColumnKeys.value.includes(c.key)));
+.filter((c) => c.hidable && hiddenColumnKeys.value.includes(c.key)));
 
 const calculateColspan = computed(() => {
   let colspan = shownColumns.value.length;
@@ -246,8 +246,8 @@ const isMenuOpen = ref(false);
 const menuRef = ref(null);
 const menuButtonRef = ref(null);
 
-function openPopupMenu() {
-  isMenuOpen.value =!isMenuOpen.value;
+function openPopupMenu(event) {
+  isMenuOpen.value =!isMenuOpen.value || !menuButtonRef.value.contains(event.target);
 }
 
 function closeMenuOnClickOutside(event) {

--- a/lib/plugins/fontawesome.js
+++ b/lib/plugins/fontawesome.js
@@ -13,6 +13,7 @@ import {
   faAngleLeft,
   faAngleRight,
   faAngleDoubleRight,
+  faEllipsisH,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -28,4 +29,5 @@ library.add(
   faAngleLeft,
   faAngleRight,
   faAngleDoubleRight,
+  faEllipsisH,
 );


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Adds an option to display actions inside of a popup menu.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.10.0--canary.40.e139f204cd23d04e1b89bae493d3f13519f3f4c9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.10.0--canary.40.e139f204cd23d04e1b89bae493d3f13519f3f4c9.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.10.0--canary.40.e139f204cd23d04e1b89bae493d3f13519f3f4c9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

FYI @verena-ifx 
