### PR TITLE
Enhancement: Support for displaying page wise loaded data

### DIFF
--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -1,0 +1,88 @@
+<template>
+  <div>
+    <InfineonDatatable
+      :data="pageData"
+      :columns="columns"
+      :default-sort="{ key: 'name', type: 'D' }"
+      :exportable="true"
+      :onPageChange="onPageChange"
+      :paging="{
+        onPageChange: onPageChange,
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+        pageData: pageData,
+        pageCount: pageCount,
+      }"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { InfineonDatatable } from '../../../../lib';
+
+const rows = ref([
+  { id: 1, name: 'item1', description: 'description item 1' },
+  { id: 2, name: 'item2,dealing,with,commas', description: 'description item 2' },
+  { id: 3, name: 'item3,\'dealing with single quotes\'', description: 'description item 3' },
+  { id: 4, name: 'item4,"dealing with double quotes"', description: 'description item 4' },
+  { id: 5, name: 'item5,"dealing with double quotes",followed by a comma', description: 'description item 5' },
+  { id: 6, name: 'item6, dealing with backslash\\', description: 'description item 6' },
+  { id: 7, name: 'item7, dealing with backslash\\ and newline\nnewline should appear here', description: 'description item 7' },
+]);
+for (let i = 8; i <= 50; i++) {
+  rows.value.push({
+    id: i,
+    name: 'item' + i,
+    description: 'description item ' + i
+  });
+}
+
+const pageNumber = ref(0);
+const pageSize = ref(10);
+const pageCount = computed(() => {
+  return rows.value ? rows.value.length : 0;
+  // if (count / currentPageSize.value < currentPage.value) {
+  //   currentPage.value = parseInt(pageCount.value / currentPageSize.value, 10);
+  // }
+});
+// const sorting = ref({ })
+
+const pageData = computed(() => {
+  return rows.value.slice(
+    pageNumber.value * pageSize.value,
+    (pageNumber.value + 1) * pageSize.value,
+  )
+});
+
+const onPageChange = (newPageNumber, newPageSize, sorting) => {
+  // eslint-disable-next-line no-alert
+  // alert(`Page changed. \n Page number: ${pageNumber}, Page size: ${pageSize}, Sorted column: ${sortedColumn}, Sort order: ${sortOrder}`);
+  let newSorting = sorting ? sorting : { key: '-', type: '-' };
+  console.log(`Page changed. \n Page number: ${newPageNumber}, Page size: ${newPageSize}, Sorted column: ${newSorting.key}, Sort order: ${newSorting.type}`);
+  console.log(sorting);
+  pageNumber.value = newPageNumber;
+  pageSize.value = newPageSize;
+}
+
+const columns = [
+  {
+    key: 'id',
+    title: 'ID column title',
+    sortable: true,
+    sortType: 'NUMBER',
+  },
+  {
+    key: 'name',
+    title: 'Column 1',
+    sortable: true,
+    sortType: 'STRING',
+  },
+  {
+    key: 'description',
+    title: 'Description',
+    sortable: true,
+    sortType: 'STRING',
+  },
+];
+</script>

--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -12,7 +12,11 @@
         onPageChange: onPageChange,
         fetchAllData: fetchAllData,
       }" />
-    <button class="btn btn-sm btn-primary" title="Download CSV File" @click="loadDataRandom">
+    <button 
+      class="btn btn-sm btn-primary" 
+      title="Download CSV File" 
+      @click="loadDataRandom"
+    >
       Load Data
     </button>
     <div>
@@ -39,7 +43,7 @@ const loadData = (dataCount) => {
     data.push({
       id: i,
       name: 'item' + i,
-      description: 'description item ' + i
+      description: 'description item ${i}'
     });
   }
   return data;

--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -12,6 +12,7 @@
         pageSize: pageSize,
         pageData: pageData,
         pageCount: pageCount,
+        fetchAllData: fetchAllData,
       }"
     />
   </div>
@@ -107,6 +108,8 @@ const onPageChange = (newPageNumber, newPageSize, incomingSorting) => {
   pageSize.value = newPageSize;
   sorting.value = incomingSorting; 
 }
+
+const fetchAllData = () => rows.value;
 
 const columns = [
   {

--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -1,20 +1,23 @@
 <template>
   <div>
-    <InfineonDatatable
-      :data="pageData"
-      :columns="columns"
-      :default-sort="{ key: 'name', type: 'D' }"
+    <InfineonDatatable 
+      :data="pageData" 
+      :columns="columns" 
+      :default-sort="{ key: 'name', type: 'D' }" 
       :exportable="true"
-      :onPageChange="onPageChange"
       :paging="{
-        onPageChange: onPageChange,
         pageNumber: pageNumber,
         pageSize: pageSize,
-        pageData: pageData,
-        pageCount: pageCount,
+        totalDataCount: totalCount,
+        onPageChange: onPageChange,
         fetchAllData: fetchAllData,
-      }"
-    />
+      }" />
+    <button class="btn btn-sm btn-primary" title="Download CSV File" @click="loadDataRandom">
+      Load Data
+    </button>
+    <div>
+      Total data count: {{ totalCount }}
+    </div>
   </div>
 </template>
 
@@ -22,26 +25,36 @@
 import { computed, ref } from 'vue';
 import { InfineonDatatable } from '../../../../lib';
 
-const rows = ref([
-  { id: 1, name: 'item1', description: 'description item 1' },
-  { id: 2, name: 'item2,dealing,with,commas', description: 'description item 2' },
-  { id: 3, name: 'item3,\'dealing with single quotes\'', description: 'description item 3' },
-  { id: 4, name: 'item4,"dealing with double quotes"', description: 'description item 4' },
-  { id: 5, name: 'item5,"dealing with double quotes",followed by a comma', description: 'description item 5' },
-  { id: 6, name: 'item6, dealing with backslash\\', description: 'description item 6' },
-  { id: 7, name: 'item7, dealing with backslash\\ and newline\nnewline should appear here', description: 'description item 7' },
-]);
-for (let i = 8; i <= 50; i++) {
-  rows.value.push({
-    id: i,
-    name: 'item' + i,
-    description: 'description item ' + i
-  });
-}
+const loadData = (dataCount) => {
+  const data = [
+    { id: 1, name: 'item1', description: 'description item 1' },
+    { id: 2, name: 'item2,dealing,with,commas', description: 'description item 2' },
+    { id: 3, name: 'item3,\'dealing with single quotes\'', description: 'description item 3' },
+    { id: 4, name: 'item4,"dealing with double quotes"', description: 'description item 4' },
+    { id: 5, name: 'item5,"dealing with double quotes",followed by a comma', description: 'description item 5' },
+    { id: 6, name: 'item6, dealing with backslash\\', description: 'description item 6' },
+    { id: 7, name: 'item7, dealing with backslash\\ and newline\nnewline should appear here', description: 'description item 7' },
+  ];
+  for (let i = 8; i <= dataCount; i++) {
+    data.push({
+      id: i,
+      name: 'item' + i,
+      description: 'description item ' + i
+    });
+  }
+  return data;
+};
+
+const loadDataRandom = () => {
+  const randomCount = Math.floor(Math.random() * (160 - 40 + 1)) + 40;
+  rows.value = loadData(randomCount)
+};
+
+const rows = ref(loadData(50));
 
 const pageNumber = ref(0);
 const pageSize = ref(10);
-const pageCount = computed(() => {
+const totalCount = computed(() => {
   return rows.value ? rows.value.length : 0;
 });
 const sorting = ref(undefined)
@@ -94,7 +107,7 @@ const pageData = computed(() => {
 const onPageChange = (newPageNumber, newPageSize, incomingSorting) => {
   pageNumber.value = newPageNumber;
   pageSize.value = newPageSize;
-  sorting.value = incomingSorting; 
+  sorting.value = incomingSorting;
 }
 
 const fetchAllData = () => rows.value;

--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -46,23 +46,66 @@ const pageCount = computed(() => {
   //   currentPage.value = parseInt(pageCount.value / currentPageSize.value, 10);
   // }
 });
-// const sorting = ref({ })
+const sorting = ref(undefined)
 
 const pageData = computed(() => {
-  return rows.value.slice(
+
+  const sortedData = rows.value.slice(0);
+  if (sorting.value && sorting.value.key) {
+    const { key, type } = sorting.value;
+    const realColumns = columns.filter((c) => c.visible === undefined || c.visible === false);
+    const foundColumn = realColumns.find((c) => c.key === key);
+    if (foundColumn) {
+      const {
+        sortType,
+        valueResolver,
+        filterResolverKey,
+      } = foundColumn;
+      if (filterResolverKey || !valueResolver) {
+        const vKey = filterResolverKey || key;
+
+        if (sortType === 'NUMBER' && type === 'D') {
+          sortedData.sort((a, b) => b[vKey] - a[vKey]);
+        } else if (sortType === 'NUMBER' && type === 'A') {
+          sortedData.sort((a, b) => a[vKey] - b[vKey]);
+        } else if (sortType === 'STRING' && type === 'D') {
+          sortedData.sort((a, b) => b[vKey]?.localeCompare(a[vKey]));
+        } else if (sortType === 'STRING' && type === 'A') {
+          sortedData.sort((a, b) => a[vKey]?.localeCompare(b[vKey]));
+        }
+      } else if (valueResolver) {
+        if (sortType === 'NUMBER' && type === 'D') {
+          sortedData.sort((a, b) => valueResolver(b) - valueResolver(a));
+        } else if (sortType === 'NUMBER' && type === 'A') {
+          sortedData.sort((a, b) => valueResolver(a) - valueResolver(b));
+        } else if (sortType === 'STRING' && type === 'D') {
+          sortedData.sort((a, b) => valueResolver(b)?.localeCompare(valueResolver(a)));
+        } else if (sortType === 'STRING' && type === 'A') {
+          sortedData.sort((a, b) => valueResolver(a)?.localeCompare(valueResolver(b)));
+        }
+      }
+    }
+  }
+
+  console.log('------------------------');
+  console.log(sortedData);
+  console.log('------------------------');
+
+  return sortedData.slice(
     pageNumber.value * pageSize.value,
     (pageNumber.value + 1) * pageSize.value,
   )
 });
 
-const onPageChange = (newPageNumber, newPageSize, sorting) => {
+const onPageChange = (newPageNumber, newPageSize, incomingSorting) => {
   // eslint-disable-next-line no-alert
   // alert(`Page changed. \n Page number: ${pageNumber}, Page size: ${pageSize}, Sorted column: ${sortedColumn}, Sort order: ${sortOrder}`);
-  let newSorting = sorting ? sorting : { key: '-', type: '-' };
+  let newSorting = incomingSorting ? incomingSorting : { key: '-', type: '-' };
   console.log(`Page changed. \n Page number: ${newPageNumber}, Page size: ${newPageSize}, Sorted column: ${newSorting.key}, Sort order: ${newSorting.type}`);
-  console.log(sorting);
+  console.log(newSorting);
   pageNumber.value = newPageNumber;
   pageSize.value = newPageSize;
+  sorting.value = incomingSorting; 
 }
 
 const columns = [

--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -110,8 +110,16 @@ const onPageChange = (newPageNumber, newPageSize, incomingSorting) => {
   sorting.value = incomingSorting;
 }
 
-const fetchAllData = () => rows.value;
+function waitForTime(time) {
+  return new Promise(resolve => {
+    setTimeout(resolve, time);
+  });
+}
 
+const fetchAllData = async () => {
+  await waitForTime(10000);
+  return rows.value;
+}
 const columns = [
   {
     key: 'id',

--- a/examples/src/components/examples/ExamplePagingSupport.vue
+++ b/examples/src/components/examples/ExamplePagingSupport.vue
@@ -43,9 +43,6 @@ const pageNumber = ref(0);
 const pageSize = ref(10);
 const pageCount = computed(() => {
   return rows.value ? rows.value.length : 0;
-  // if (count / currentPageSize.value < currentPage.value) {
-  //   currentPage.value = parseInt(pageCount.value / currentPageSize.value, 10);
-  // }
 });
 const sorting = ref(undefined)
 
@@ -88,10 +85,6 @@ const pageData = computed(() => {
     }
   }
 
-  console.log('------------------------');
-  console.log(sortedData);
-  console.log('------------------------');
-
   return sortedData.slice(
     pageNumber.value * pageSize.value,
     (pageNumber.value + 1) * pageSize.value,
@@ -99,11 +92,6 @@ const pageData = computed(() => {
 });
 
 const onPageChange = (newPageNumber, newPageSize, incomingSorting) => {
-  // eslint-disable-next-line no-alert
-  // alert(`Page changed. \n Page number: ${pageNumber}, Page size: ${pageSize}, Sorted column: ${sortedColumn}, Sort order: ${sortOrder}`);
-  let newSorting = incomingSorting ? incomingSorting : { key: '-', type: '-' };
-  console.log(`Page changed. \n Page number: ${newPageNumber}, Page size: ${newPageSize}, Sorted column: ${newSorting.key}, Sort order: ${newSorting.type}`);
-  console.log(newSorting);
   pageNumber.value = newPageNumber;
   pageSize.value = newPageSize;
   sorting.value = incomingSorting; 

--- a/examples/src/components/global/TheHeader.vue
+++ b/examples/src/components/global/TheHeader.vue
@@ -111,6 +111,10 @@ const links = ref([
         routeName: 'examplePopupMenuActions',
       },
       {
+        label: 'Paging Support',
+        routeName: 'examplePagingSupport',
+      },
+      {
         label: 'CSV Export',
         routeName: 'exampleCsvExport',
       },

--- a/examples/src/router/router.js
+++ b/examples/src/router/router.js
@@ -11,6 +11,7 @@ import ExampleCsvExport from '../components/examples/ExampleCsvExport.vue';
 import ExampleColumnAlwaysHiddenButExportable from '../components/examples/ExampleColumnAlwaysHiddenButExportable.vue';
 import ExampleConditionallyHideAdditionalActions from '../components/examples/ExampleConditionallyHideAdditionalActions.vue';
 import IntroPage from '../components/IntroPage.vue';
+import ExamplePagingSupport from '../components/examples/ExamplePagingSupport.vue';
 
 // this file initializes the vue router
 // it maps the component of the route to the <router-view> in App.vue
@@ -62,6 +63,11 @@ const router = createRouter({
       path: '/example-popup-menu-actions',
       name: 'examplePopupMenuActions',
       component: ExamplePopupMenuActions,
+    },
+    {
+      path: '/example-paging-support',
+      name: 'examplePagingSupport',
+      component: ExamplePagingSupport,
     },
     {
       path: '/example-conditionally-hide-columns',

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -71,6 +71,7 @@ import DatatableRow from './InfineonDatatableRow.vue';
 import DatatablePager from './InfineonDatatablePager.vue';
 import DatatableSortIcon from './InfineonDatatableSortIcon.vue';
 import DatatableShowColumnsPicker from './InfineonDatatableShowColumnsPicker.vue';
+import { debounce } from '../plugins/treeView/src/utils';
 
 const props = defineProps({
   canEdit: Boolean,
@@ -89,6 +90,7 @@ const props = defineProps({
     pageNumber: Number,
     pageSize: Number,
     pageCount: Number,
+    fetchAllData: Function,
   },
 });
 const emit = defineEmits(['saveRow', 'editModeValue', 'cancelRow', 'onMenuButtonClick']);
@@ -259,7 +261,9 @@ async function exportCSV() {
   let csv = titles.join(',');
   csv += '\n';
 
-  data.value.forEach((row) => {
+  const exportData = paging.value ? paging.value.fetchAllData() : data.value;
+
+  exportData.forEach((row) => {
     const values = columnsToExport
       .map((col) => (col.valueResolver
         ? `"${(col.valueResolver(row) && col.valueResolver(row).replace && col.valueResolver(row).replace(/(["])/g, '"$1').replace(/(?:\r\n|\r|\n)/g, ' ')) || col.valueResolver(row)}"`

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -86,10 +86,10 @@ const props = defineProps({
   // customColHidden: { type: String, default: 'Custom column' },
   popupMenuActions: { type: Array, default: () => [] },
   paging: {
-    onPageChange: Function,
     pageNumber: Number,
     pageSize: Number,
-    pageCount: Number,
+    totalDataCount: Number,
+    onPageChange: Function,
     fetchAllData: Function,
   },
 });
@@ -101,9 +101,9 @@ const {
 const sortColumn = ref(props.defaultSort);
 const currentPage = ref(paging.value ? paging.value.pageNumber : 0);
 const currentPageSize = ref(paging.value ? paging.value.pageSize : 10);
+const count = ref(paging.value ? paging.value.totalDataCount : 0);
 const rowInEditMode = ref(undefined);
 const rowMenuIsOpen = ref(undefined);
-const count = ref(paging.value ? paging.value.pageCount : 0);
 
 const hiddenColumnKeys = ref([]);
 
@@ -122,9 +122,11 @@ watch(
   (newData) => {
     if (!paging.value) {
       count.value = newData ? newData.length : 0;
-      if (count.value / currentPageSize.value < currentPage.value) {
-        currentPage.value = parseInt(count.value / currentPageSize.value, 10);
-      }
+    } else {
+      count.value = paging.value.totalDataCount;
+    }
+    if (count.value / currentPageSize.value < currentPage.value) {
+      currentPage.value = parseInt(count.value / currentPageSize.value, 10);
     }
   },
   { immediate: true },
@@ -169,8 +171,8 @@ const processedData = computed(() => {
       }
     } 
   } else {
-      paging.value.onPageChange(currentPage.value, currentPageSize.value, sortColumn.value);
-    }
+    paging.value.onPageChange(currentPage.value, currentPageSize.value, sortColumn.value);
+  }
 
   // Place where the currently displayed data is computed, gets triggered on currentPage and pageSizeChanges
   const sliced = !paging.value ? sortedData.slice(

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -98,9 +98,7 @@ const emit = defineEmits(['saveRow', 'editModeValue', 'cancelRow', 'onMenuButton
 const {
   data, columns, localStorageKey, paging,
 } = toRefs(props);
-// const data = ref(paging.value ? paging.pageData : props.data)
 const sortColumn = ref(props.defaultSort);
-console.log(paging);
 const currentPage = ref(paging.value ? paging.value.pageNumber : 0);
 const currentPageSize = ref(paging.value ? paging.value.pageSize : 10);
 const rowInEditMode = ref(undefined);
@@ -122,8 +120,6 @@ const shownColumns = computed(() => realColumns.value
 watch(
   data,
   (newData) => {
-    console.log('----- data watch triggered ----')
-    console.log(`Current data count: ${newData.length}`)
     if (!paging.value) {
       count.value = newData ? newData.length : 0;
       if (count.value / currentPageSize.value < currentPage.value) {
@@ -136,8 +132,6 @@ watch(
 
 const processedData = computed(() => {
   const sortedData = data.value.slice(0);
-  console.log('###############################');
-  // const tmp = sortColumn.value;
   if (!paging.value) {
     if (sortColumn.value && sortColumn.value.key) {
       const { key, type } = sortColumn.value;
@@ -175,7 +169,6 @@ const processedData = computed(() => {
       }
     } 
   } else {
-      console.log('Notify changed filter');
       paging.value.onPageChange(currentPage.value, currentPageSize.value, sortColumn.value);
     }
 
@@ -184,8 +177,6 @@ const processedData = computed(() => {
     currentPage.value * currentPageSize.value,
     (currentPage.value + 1) * currentPageSize.value,
   ) : sortedData;
-  // const sliced = sortedData;
-
   return sliced;
 });
 
@@ -226,7 +217,6 @@ async function saveRow(row) {
   rowInEditMode.value = undefined;
 }
 function editModeValue(row) {
-  // console.log('edit mode val', row);
   emit('editModeValue', row);
 }
 
@@ -247,7 +237,6 @@ function updatePageSize(size) {
 }
 
 function updatePageNumber(number) {
-  // currentPage.value = number;
   if (paging.value) {
     paging.value.onPageChange(currentPage.value, currentPageSize.value, sortColumn.value)
   }

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -252,7 +252,7 @@ async function exportCSV() {
   let csv = titles.join(',');
   csv += '\n';
 
-  const exportData = paging.value ? paging.value.fetchAllData() : data.value;
+  const exportData = paging.value ? await paging.value.fetchAllData() : data.value;
 
   exportData.forEach((row) => {
     const values = columnsToExport

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -1,137 +1,57 @@
 <template>
-  <div
-    class="d-flex flex-column justify-content-center flex-grow-1 pt-3"
-    style="overflow:auto"
-  >
-    <div
-      class="flex-grow-1"
-      style="overflow:auto"
-    >
-      <table
-        class="table table-sm table-hover w-100"
-        style="border-collapse: separate;border-spacing: 0;"
-      >
+  <div class="d-flex flex-column justify-content-center flex-grow-1 pt-3" style="overflow:auto">
+    <div class="flex-grow-1" style="overflow:auto">
+      <table class="table table-sm table-hover w-100" style="border-collapse: separate;border-spacing: 0;">
         <thead>
           <tr>
-            <th
-              v-if="hiddenColumns.length > 0"
-              style="width:0em"
-              class="p-0"
-            />
-            <th
-              v-if="canEdit || additionalActions.length > 0"
-              style="width:0em"
-              class="ps-2 pe-1"
-            >
-              <slot
-                :name="`column.actions`"
-                v-bind="{title: 'Actions'}"
-              />
-              <slot
-                v-if="!$slots[`column.actions`]"
-                name="column"
-                v-bind="{title: 'Actions'}"
-              >
+            <th v-if="hiddenColumns.length > 0" style="width:0em" class="p-0" />
+            <th v-if="canEdit || additionalActions.length > 0" style="width:0em" class="ps-2 pe-1">
+              <slot :name="`column.actions`" v-bind="{ title: 'Actions' }" />
+              <slot v-if="!$slots[`column.actions`]" name="column" v-bind="{ title: 'Actions' }">
                 Actions
               </slot>
             </th>
 
-            <th
-              v-for="(column, index) in shownColumns"
-              :key="index"
-              class="text-nowrap"
-              scope="col"
-            >
+            <th v-for="(column, index) in shownColumns" :key="index" class="text-nowrap" scope="col">
               <!--default column title slot - hidden for slot with specified column title-->
-              <slot
-                v-if="!$slots[`column.${column.title}`]"
-                name="column"
-                v-bind="column"
-              >
+              <slot v-if="!$slots[`column.${column.title}`]" name="column" v-bind="column">
                 {{ column.title }}
               </slot>
 
               <!--special column title slot-->
-              <slot
-                :name="`column.${column.title}`"
-                v-bind="column"
-              />
+              <slot :name="`column.${column.title}`" v-bind="column" />
 
-              <DatatableSortIcon
-                v-model:sort-column="sortColumn"
-                :column="column"
-              />
+              <DatatableSortIcon v-model:sort-column="sortColumn" :column="column" />
 
-              <a
-                v-if="column.hidable"
-                style="cursor: pointer"
-                @click="changeColumnVisibility(column.key)"
-              >
-                <font-awesome-icon
-                  class="fa-sm ms-2"
-                  :icon="['fas', 'times']"
-                />
+              <a v-if="column.hidable" style="cursor: pointer" @click="changeColumnVisibility(column.key)">
+                <font-awesome-icon class="fa-sm ms-2" :icon="['fas', 'times']" />
               </a>
             </th>
           </tr>
         </thead>
 
         <tbody>
-          <DatatableRow
-            v-for="(row,idx) in processedData"
-            :key="row.id"
-            :row-index="idx"
-            :row="row"
-            :columns="realColumns"
-            :hidden-column-keys="hiddenColumnKeys"
-            :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)"
-            :can-edit="canEdit"
-            :additional-actions="additionalActions"
-            :popup-menu-actions="popupMenuActions"
-            :is-menu-open="(row.id) === (rowMenuIsOpen?.id)"
-            @start-edit-row="startEditRow"
-            @save-row="saveRow"
-            @cancel-row="cancelRow"
-            @edit-mode-value="editModeValue"
-            @on-menu-button-click="closeOtherActionsPopupMenus"
-          >
-            <template
-              v-for="(_, name) in $slots"
-              #[name]="slotData"
-            >
-              <slot
-                :name="name"
-                v-bind="slotData || {}"
-              />
+          <DatatableRow v-for="(row, idx) in processedData" :key="row.id" :row-index="idx" :row="row"
+            :columns="realColumns" :hidden-column-keys="hiddenColumnKeys"
+            :row-is-in-edit-mode="(row.id) === (rowInEditMode?.id)" :can-edit="canEdit"
+            :additional-actions="additionalActions" :popup-menu-actions="popupMenuActions"
+            :is-menu-open="(row.id) === (rowMenuIsOpen?.id)" @start-edit-row="startEditRow" @save-row="saveRow"
+            @cancel-row="cancelRow" @edit-mode-value="editModeValue"
+            @on-menu-button-click="closeOtherActionsPopupMenus">
+            <template v-for="(_, name) in $slots" #[name]="slotData">
+              <slot :name="name" v-bind="slotData || {}" />
             </template>
           </DatatableRow>
         </tbody>
       </table>
     </div>
     <div class="mt-1 d-flex flex-row">
-      <DatatablePager
-        v-model:currentPage="currentPage"
-        class="flex-grow-1"
-        :page-size="currentPageSize"
-        :count="count"
-        @update-page-size="updatePageSize"
-        @update:currentPage="updatePageNumber"
-      />
-      <DatatableShowColumnsPicker
-        style="max-width:15em"
-        :columns="realColumns"
-        :hidden-column-keys="hiddenColumnKeys"
-        @change-column-visibility="changeColumnVisibility"
-      />
-      <div
-        v-if="exportable"
-        class="mt-1 ms-1"
-      >
-        <button
-          class="btn btn-sm btn-primary"
-          title="Download CSV File"
-          @click="exportCSV"
-        >
+      <DatatablePager v-model:currentPage="currentPage" class="flex-grow-1" :page-size="currentPageSize" :count="count"
+        @update-page-size="updatePageSize" @update:currentPage="updatePageNumber" />
+      <DatatableShowColumnsPicker style="max-width:15em" :columns="realColumns" :hidden-column-keys="hiddenColumnKeys"
+        @change-column-visibility="changeColumnVisibility" />
+      <div v-if="exportable" class="mt-1 ms-1">
+        <button class="btn btn-sm btn-primary" title="Download CSV File" @click="exportCSV">
           <font-awesome-icon :icon="['fas', 'file-download']" />
           Download
         </button>
@@ -168,7 +88,6 @@ const props = defineProps({
     onPageChange: Function,
     pageNumber: Number,
     pageSize: Number,
-    pageData: Array,
     pageCount: Number,
   },
 });
@@ -215,41 +134,48 @@ watch(
 
 const processedData = computed(() => {
   const sortedData = data.value.slice(0);
-  if (sortColumn.value && sortColumn.value.key) {
-    const { key, type } = sortColumn.value;
+  console.log('###############################');
+  // const tmp = sortColumn.value;
+  if (!paging.value) {
+    if (sortColumn.value && sortColumn.value.key) {
+      const { key, type } = sortColumn.value;
 
-    const foundColumn = realColumns.value.find((c) => c.key === key);
-    if (foundColumn) {
-      const {
-        sortType,
-        valueResolver,
-        filterResolverKey,
-      } = foundColumn;
-      if (filterResolverKey || !valueResolver) {
-        const vKey = filterResolverKey || key;
+      const foundColumn = realColumns.value.find((c) => c.key === key);
+      if (foundColumn) {
+        const {
+          sortType,
+          valueResolver,
+          filterResolverKey,
+        } = foundColumn;
+        if (filterResolverKey || !valueResolver) {
+          const vKey = filterResolverKey || key;
 
-        if (sortType === 'NUMBER' && type === 'D') {
-          sortedData.sort((a, b) => b[vKey] - a[vKey]);
-        } else if (sortType === 'NUMBER' && type === 'A') {
-          sortedData.sort((a, b) => a[vKey] - b[vKey]);
-        } else if (sortType === 'STRING' && type === 'D') {
-          sortedData.sort((a, b) => b[vKey]?.localeCompare(a[vKey]));
-        } else if (sortType === 'STRING' && type === 'A') {
-          sortedData.sort((a, b) => a[vKey]?.localeCompare(b[vKey]));
-        }
-      } else if (valueResolver) {
-        if (sortType === 'NUMBER' && type === 'D') {
-          sortedData.sort((a, b) => valueResolver(b) - valueResolver(a));
-        } else if (sortType === 'NUMBER' && type === 'A') {
-          sortedData.sort((a, b) => valueResolver(a) - valueResolver(b));
-        } else if (sortType === 'STRING' && type === 'D') {
-          sortedData.sort((a, b) => valueResolver(b)?.localeCompare(valueResolver(a)));
-        } else if (sortType === 'STRING' && type === 'A') {
-          sortedData.sort((a, b) => valueResolver(a)?.localeCompare(valueResolver(b)));
+          if (sortType === 'NUMBER' && type === 'D') {
+            sortedData.sort((a, b) => b[vKey] - a[vKey]);
+          } else if (sortType === 'NUMBER' && type === 'A') {
+            sortedData.sort((a, b) => a[vKey] - b[vKey]);
+          } else if (sortType === 'STRING' && type === 'D') {
+            sortedData.sort((a, b) => b[vKey]?.localeCompare(a[vKey]));
+          } else if (sortType === 'STRING' && type === 'A') {
+            sortedData.sort((a, b) => a[vKey]?.localeCompare(b[vKey]));
+          }
+        } else if (valueResolver) {
+          if (sortType === 'NUMBER' && type === 'D') {
+            sortedData.sort((a, b) => valueResolver(b) - valueResolver(a));
+          } else if (sortType === 'NUMBER' && type === 'A') {
+            sortedData.sort((a, b) => valueResolver(a) - valueResolver(b));
+          } else if (sortType === 'STRING' && type === 'D') {
+            sortedData.sort((a, b) => valueResolver(b)?.localeCompare(valueResolver(a)));
+          } else if (sortType === 'STRING' && type === 'A') {
+            sortedData.sort((a, b) => valueResolver(a)?.localeCompare(valueResolver(b)));
+          }
         }
       }
+    } 
+  } else {
+      console.log('Notify changed filter');
+      paging.value.onPageChange(currentPage.value, currentPageSize.value, sortColumn.value);
     }
-  }
 
   // Place where the currently displayed data is computed, gets triggered on currentPage and pageSizeChanges
   const sliced = !paging.value ? sortedData.slice(

--- a/lib/plugins/fontawesome.js
+++ b/lib/plugins/fontawesome.js
@@ -14,6 +14,7 @@ import {
   faAngleRight,
   faAngleDoubleRight,
   faEllipsisH,
+  faFileDownload,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -30,4 +31,5 @@ library.add(
   faAngleRight,
   faAngleDoubleRight,
   faEllipsisH,
+  faFileDownload,
 );


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Adds an option to customize handling of changes which affect the currently displayed page in the table. This can be used to display page wise loaded data in the table. It behaves like all data is present but in fact, only the data items of the currently visible table page is handed to the data table component. 

Switching pages, changing page size, sorting of columns and the csv export are all adapted and work with the new changes. 

The behavior of the data table does not change with this PR. For the user, the table behaves the same, with or without this new option. The changes are only technical and in the background.

Related Issue
Related to [#41 Option to customize handling of page size, page number or sorting changes](https://github.com/Infineon/infineon-vue-datatable/issues/41)

FYI @verena-ifx 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.0--canary.42.68df4d5efaebcd082d008382ac8a12bb3e25ef0f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.11.0--canary.42.68df4d5efaebcd082d008382ac8a12bb3e25ef0f.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.11.0--canary.42.68df4d5efaebcd082d008382ac8a12bb3e25ef0f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
