### PR TITLE
Add optional sticky header to data table component

### DIFF
--- a/examples/src/App.vue
+++ b/examples/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex flex-row  h-100">
+  <div style="height: 100vh; overflow: hidden;" class="d-flex flex-row  h-100">
     <the-header />
     <router-view
       class="flex-grow-1"

--- a/examples/src/components/examples/ExampleStickyHeader.vue
+++ b/examples/src/components/examples/ExampleStickyHeader.vue
@@ -18,10 +18,9 @@
       nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue
       duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer.
     </div>
-      <InfineonDatatable :data="rows" :columns="columns" :default-sort="{ key: 'name', type: 'D' }" :sticky-header="true" />
-    
+    <InfineonDatatable :data="rows" :columns="columns" :default-sort="{ key: 'name', type: 'D' }"
+      :sticky-header="true" />
   </div>
-
 </template>
 
 <script setup>

--- a/examples/src/components/examples/ExampleStickyHeader.vue
+++ b/examples/src/components/examples/ExampleStickyHeader.vue
@@ -1,0 +1,50 @@
+<template>
+  <div style="display: flex; flex-direction: column; max-width: 80%; overflow: auto;">
+    <div>
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+      dolore
+      magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+      gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+      sadipscing
+      elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero
+      eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+      ipsum
+      dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+      labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+      Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+      Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu
+      feugiat
+      nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue
+      duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer.
+    </div>
+      <InfineonDatatable :data="rows" :columns="columns" :default-sort="{ key: 'name', type: 'D' }" :sticky-header="true" />
+    
+  </div>
+
+</template>
+
+<script setup>
+import { InfineonDatatable } from '../../../../lib';
+
+const rows = [];
+
+for (let i = 1; i <= 50; i++) {
+  rows.push({ id: i, name: `item${i} Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.` });
+}
+
+const columns = [
+  {
+    key: 'id',
+    title: 'ID column title',
+    sortable: true,
+    sortType: 'NUMBER',
+  },
+  {
+    key: 'name',
+    title: 'Name',
+    sortable: true,
+    sortType: 'STRING',
+  },
+];
+</script>

--- a/examples/src/components/global/TheHeader.vue
+++ b/examples/src/components/global/TheHeader.vue
@@ -130,6 +130,10 @@ const links = ref([
         label: 'Export hidden column',
         routeName: 'exampleColumnAlwaysHiddenButExportable',
       },
+      {
+        label: 'Sticky Header',
+        routeName: 'exampleStickyHeader',
+      },
     ],
   },
 ]);

--- a/examples/src/router/router.js
+++ b/examples/src/router/router.js
@@ -14,6 +14,7 @@ import ExampleColumnAlwaysHiddenButExportable from '../components/examples/Examp
 import ExampleConditionallyHideAdditionalActions from '../components/examples/ExampleConditionallyHideAdditionalActions.vue';
 import IntroPage from '../components/IntroPage.vue';
 import ExamplePagingSupport from '../components/examples/ExamplePagingSupport.vue';
+import ExampleStickyHeader from '../components/examples/ExampleStickyHeader.vue';
 
 // this file initializes the vue router
 // it maps the component of the route to the <router-view> in App.vue
@@ -95,6 +96,11 @@ const router = createRouter({
       path: '/example-always-hidden-but-exportable',
       name: 'exampleColumnAlwaysHiddenButExportable',
       component: ExampleColumnAlwaysHiddenButExportable,
+    },
+    {
+      path: '/example-sticky-header',
+      name: 'exampleStickyHeader',
+      component: ExampleStickyHeader,
     },
   ],
 });

--- a/lib/datatable/InfineonDatatable.vue
+++ b/lib/datatable/InfineonDatatable.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="d-flex flex-column justify-content-center flex-grow-1 pt-3" style="overflow:auto">
-    <div class="flex-grow-1" style="overflow:auto">
+    <div class="flex-grow-1" style="overflow-y: auto; overflow-x: auto; position: relative;">
       <table class="table table-sm table-hover w-100" style="border-collapse: separate;border-spacing: 0;">
-        <thead>
+        <thead :class="{ stickyHeader: stickyHeader }">
           <tr>
             <th v-if="hiddenColumns.length > 0" style="width:0em" class="p-0" />
             <th v-if="showActionColumn" style="width:0em" class="ps-2 pe-1">
@@ -94,11 +94,12 @@ const props = defineProps({
     onPageChange: Function,
     fetchAllData: Function,
   },
+  stickyHeader: { type: Boolean, default: false },
 });
 const emit = defineEmits(['saveRow', 'editModeValue', 'cancelRow', 'onMenuButtonClick']);
 
 const {
-  data, columns, localStorageKey, paging,
+  data, columns, localStorageKey, paging, stickyHeader
 } = toRefs(props);
 const sortColumn = ref(props.defaultSort);
 const currentPage = ref(paging.value ? paging.value.pageNumber : 0);
@@ -328,7 +329,11 @@ function downloadFile() {
 .stickyHeader {
   position: sticky;
   top: 0;
-  border-bottom: 2px solid black;
-  background-color: white
+  z-index: 1;
+  background-color: white;
+}
+
+.stickyHeader th {
+  border-bottom: 2px solid #dee2e6;
 }
 </style>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
This PR adds an optional sticky header to the data table. It can be activated by setting :sticky-header="true" in the caller of the InfineonDatatable.

Related Issue
[Sticky Header for the Table #53](https://github.com/Infineon/infineon-vue-datatable/issues/53)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.11.6--canary.54.f26fca9cd46e545d0fbff1201bf42c33fff32691.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-vue-datatable@0.11.6--canary.54.f26fca9cd46e545d0fbff1201bf42c33fff32691.0
  # or 
  yarn add @infineon/infineon-vue-datatable@0.11.6--canary.54.f26fca9cd46e545d0fbff1201bf42c33fff32691.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
